### PR TITLE
Add a maxWait argument that allows the save to happen at a throttled …

### DIFF
--- a/src/__tests__/index-test.js
+++ b/src/__tests__/index-test.js
@@ -20,6 +20,24 @@ describe('debounce', () => {
         setTimeout(() => { save.should.have.been.called; done(); }, 15);
     });
 
+    it('should override save with a minimum set', (done) => {
+        const save = sinon.stub().resolves();
+        const engine = debounce({ save }, 30, 160);
+
+        const saveEngine = () => {
+            engine.save({});
+        };
+
+        for (let i = 0; i < 300; i += 20) {
+            setTimeout(saveEngine, i);
+        }
+
+        setTimeout(() => {
+            save.should.have.been.calledOnce;
+            done();
+        }, 170);
+    });
+
     it('should reject waiting save calls if another comes in', async () => {
         const save = sinon.stub().resolves();
         const engine = debounce({ save }, 10);


### PR DESCRIPTION
…rate during intensive dispatch sessions

Not sure if this is any interest to your package, we're running this in our own fork, since we needed to bypass the debounce every so often
