### PR TITLE
Fix self-triggered save on beforeunload

### DIFF
--- a/src/__tests__/index-test.js
+++ b/src/__tests__/index-test.js
@@ -76,6 +76,19 @@ describe('debounce', () => {
         }, 25);
     });
 
+    it('should not self-trigger save if beforeunload is triggered after timeout is cleared', (done) => {
+        const save = sinon.stub().resolves();
+        const engine = debounce({ save }, 0);
+
+        engine.save({});
+
+        setTimeout(() => {
+            window.dispatchEvent('beforeunload');
+            save.should.have.been.calledOnce;
+            done();
+        }, 25);
+    });
+
     it('should not fail if window is missing', () => {
         const oldWindow = global.window;
         delete global.window;

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,8 @@ export default (engine, ms, maxWait = null) => {
 
             clearTimeout(lastTimeout);
             clearTimeout(maxTimeout);
+            lastTimeout = null;
+            maxTimeout = null;
             lastReject = null;
             engine.save(lastState);
         });
@@ -29,6 +31,7 @@ export default (engine, ms, maxWait = null) => {
         save(state) {
             lastState = state;
             clearTimeout(lastTimeout);
+            lastTimeout = null;
 
             if (lastReject) {
                 lastReject(Error('Debounced, newer action pending'));
@@ -39,6 +42,8 @@ export default (engine, ms, maxWait = null) => {
                 const doSave = () => {
                     clearTimeout(lastTimeout);
                     clearTimeout(maxTimeout);
+                    lastTimeout = null;
+                    maxTimeout = null;
                     lastReject = null;
                     lastState = null;
                     engine.save(state).then(resolve).catch(reject);


### PR DESCRIPTION
Fix self-triggered save in the case beforeunload happens after timeout is cleared.

I'm just setting all the timeout handlers to null after clearing them.

This fixes bug reported in #23.
